### PR TITLE
add node + preact example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ you already know.
 - [Tonic Desktop CommonJS Example](desktop-node-tonic-cjs)
 - [Tonic Desktop ESM Example](desktop-node-tonic-esm)
 - [Kotlin/Native & Kotlin.js Desktop Example](desktop-kotlin-kotlinjs)
+- [Preact Desktop Example](desktop-node-preact)
+- [Preact Desktop + Node Example](desktop-node-preact)
 
 ## iOS Examples
 

--- a/desktop-node-preact/README.md
+++ b/desktop-node-preact/README.md
@@ -1,0 +1,41 @@
+# ssc hello
+An example of how to use Node APIs from a browser environment. This app shows a button that will cycle through the strings `beep`, `boop`, `blorp`. The state will be written to disk at `~/ssc-beep-data.txt`.
+
+You can look at the file while running this app, and see the text content change as you click the button.
+
+## use
+
+From this directory:
+```
+npm start
+```
+
+`npm start` will run two commands: `npm run build-js && ssc compile -r .` 
+
+Building the app happens in two discrete steps. First we build a standard browser app to the `public` directory. We are using `esbuild` to do this. Then `ssc.config` is configured with
+```
+input: public
+output: dist
+```
+
+So the command `ssc compile .` will the take the browser app in `public`, and build a desktop app to the `dist` folder.
+
+## structure
+
+In `src/main/index.js`, we import `system` from `ssc-node`. We mutate `system` by writing a function to the `receive` key. This is where we call any node functions -- within the `system.receive` function in the main process. This will get any args passed to `system.send` from the browser side.
+
+In the `main` file:
+
+```js
+system.receive = async (command, value) => {
+  // read data from disk
+  if (value.method && value.method === 'initState') {
+      const last = await fns.getLastState()
+      return { mode: last }
+  }
+```
+
+Then on the "browser" side, we can call that function like this:
+```js
+const res = await window.system.send({ method: 'initState' })
+```

--- a/desktop-node-preact/build.js
+++ b/desktop-node-preact/build.js
@@ -1,0 +1,64 @@
+const path = require('path')
+const fs = require('fs/promises')
+const esbuild = require('esbuild')
+const glob = require('glob')
+
+//
+// build a main and render script
+//
+
+async function main () {
+  await esbuild.build({
+    entryPoints: ['src/render/index.js'],
+    bundle: true,
+    keepNames: true,
+    // minify: true,
+    outfile: path.join('./public/', 'bundle.js'),
+    platform: 'browser'
+  })
+
+  await esbuild.build({
+    entryPoints: ['src/main/index.js'],
+    bundle: true,
+    keepNames: true,
+    // minify: true,
+    format: 'cjs',
+    outfile: path.join('./public/', 'main.js'),
+    platform: 'node'
+  })
+
+  const debug = process.argv.includes('--debug')
+
+  await cp('src/index.html', './public')
+
+  const isTest = process.argv.some(str => str.includes('--test'))
+
+  if (!isTest) return
+
+  glob('test/*.js', async (err, files) => {
+    if (err) throw err
+
+    await Promise.all(files.map(file => {
+      return esbuild.build({
+        entryPoints: [file],
+        bundle: true,
+        keepNames: true,
+        minify: false,
+        define: { global: 'window' },
+        sourcemap: debug ? 'inline' : undefined,
+        // outfile is (target dir + /filename.js)
+        outfile: path.join('./public/', path.basename(file)),
+        platform: 'browser'
+      })
+    }))
+  })
+}
+
+main()
+
+async function cp (a, b) {
+  return fs.copyFile(
+    path.resolve(a),
+    path.join(b, path.basename(a))
+  )
+}

--- a/desktop-node-preact/jsconfig.json
+++ b/desktop-node-preact/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["es2018", "dom"],
+    "noEmit": true,
+    "module": "commonjs",
+    "strict": false,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules"],
+  "include": [
+    "src/**/*.js",
+    "src/**/*.d.ts"
+  ]
+}

--- a/desktop-node-preact/package.json
+++ b/desktop-node-preact/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "ssc-hello",
+  "version": "0.0.0",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "npm run build-js && ssc compile -r .",
+    "build": "npm run build-js && ssc compile .",
+    "build-test": "npm run build-js && ssc compile --test .",
+    "build-js": "node ./build.js",
+    "test": "node ./build.js --test && ssc compile -r --test"
+  },
+  "dependencies": {
+    "@socketsupply/ssc-node": "^1.8.2",
+    "htm": "^3.1.1",
+    "preact": "^10.10.6",
+    "untildify": "^4.0.0"
+  },
+  "devDependencies": {
+    "@socketsupply/test-dom": "github:socketsupply/test-dom",
+    "esbuild": "^0.15.6",
+    "glob": "^8.0.3",
+    "tapzero": "^0.6.1"
+  },
+  "author": "nichoth",
+  "license": "ISC",
+  "description": "A minimal example of an application made with `ssc`.",
+  "directories": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/socketsupply/ssc-hello.git"
+  },
+  "keywords": [
+    "ssc"
+  ],
+  "bugs": {
+    "url": "https://github.com/socketsupply/ssc-hello/issues"
+  },
+  "homepage": "https://github.com/socketsupply/ssc-hello#readme"
+}

--- a/desktop-node-preact/src/index.html
+++ b/desktop-node-preact/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>hello</title>
+</head>
+
+<body>
+  <script src="./bundle.js"></script>
+</body>
+</html>

--- a/desktop-node-preact/src/main/index.js
+++ b/desktop-node-preact/src/main/index.js
@@ -66,6 +66,13 @@ async function main () {
             return { mode: last }
         }
 
+        //
+        // the only other option is to cycle the beeper, so if we haven't
+        // returned by now, then we call `beeper`
+        // In a real application, you would probably want a more robust
+        // protocol for RPC
+        //
+
         // write the data to disk, and get the next state
         const newMode = await fns.beeper(value)
 

--- a/desktop-node-preact/src/main/index.js
+++ b/desktop-node-preact/src/main/index.js
@@ -1,0 +1,87 @@
+// @ts-check
+'use strict'
+
+const { system } = require('@socketsupply/ssc-node')
+const path = require('path')
+const fs = require('node:fs/promises')
+const untildify = require('untildify');
+
+const fns = {
+    beeper: async (val) => {
+        const { mode } = val
+        let newMode = 'beep'
+        if (mode === 'beep') newMode = 'boop'
+        if (mode === 'boop') newMode = 'blorp'
+        if (mode === 'blorp') newMode = 'beep'
+
+        await fs.writeFile(untildify('~/ssc-beep-data.txt'), newMode)
+
+        return newMode
+    },
+
+    getLastState: async function () {
+        const content = await fs.readFile(
+            untildify('~/ssc-beep-data.txt'),
+            'utf8'
+        )
+        return content
+    }
+}
+
+async function main () {
+    const screen = await system.getScreenSize()
+
+    await system.setSize({
+        window: 0,
+        height: Math.min(900, screen.height * 0.80),
+        width: Math.min(1440, screen.width * 0.80)
+    })
+
+    await system.show({ window: 0 })
+
+    await system.setTitle({
+        window: 0,
+        value: 'wooo'
+    })
+
+    //
+    // implement a function `system.receive` to expose node APIs to the
+    // "front-end" app
+    //
+    // @ts-ignore
+    system.receive = async (command, value) => {
+        // command = 'send'
+        // value is passed by caller
+        if (command !== 'send') {
+            return console.log('unexpected command', command)
+        }
+
+        if (value && value.restart) {
+          await system.restart()
+        }
+
+        // read data from disk
+        if (value.method && value.method === 'initState') {
+            const last = await fns.getLastState()
+            return { mode: last }
+        }
+
+        // write the data to disk, and get the next state
+        const newMode = await fns.beeper(value)
+
+        // in a real application, we would need a way to throw an error
+        //   you can use a convention, like always return { data, err } as
+        //   the response from this function
+        return { received: value, mode: newMode }
+    }
+
+    const resourcesDirectory = path.dirname(process.argv[1])
+    const file = path.join(resourcesDirectory, 'index.html')
+
+    // a `file` URL to the index.html of our app
+    await system.navigate({ window: 0, value: `file://${file}` })
+}
+
+main().then(null, err => {
+    process.nextTick(() => { throw err })
+})

--- a/desktop-node-preact/src/render/index.js
+++ b/desktop-node-preact/src/render/index.js
@@ -1,0 +1,49 @@
+// @ts-check
+'use strict'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { useState, useEffect } from 'preact/hooks'
+
+function Demonstration () {
+    const [mode, setMode] = useState(null)
+
+    // component did mount
+    // read the last state from disk
+    useEffect(() => {
+        // @ts-ignore
+        window.system.send({ method: 'initState' })
+            .then(res => {
+                setMode(res.mode)
+            })
+            .catch(err => console.log('errr', err))
+    }, [])
+
+    // this shows how to do IPC API calls
+    async function handleClick (ev) {
+        ev.preventDefault()
+        // @ts-ignore
+        const res = await window.system.send({ mode })
+        const { mode: newMode } = res
+        setMode(newMode)
+    }
+
+    return html`<div class="demo">
+        <h1>hello, world</h1>
+        <p>${mode}</p>
+        <button onclick=${handleClick}>button</button>
+    </div>`
+}
+
+const testArg = process.argv.find(arg => arg.includes('--test='))
+if (testArg) {
+    const testFile = testArg.replace('--test=', '')
+    if (!testFile) throw new Error('missing test file')
+
+    const script = document.createElement('script')
+    script.setAttribute('type', 'text/javascript')
+    script.setAttribute('src', testFile)
+    document.body.appendChild(script)
+}
+
+render(html`<${Demonstration} />`, document.body)

--- a/desktop-node-preact/src/style/index.css
+++ b/desktop-node-preact/src/style/index.css
@@ -1,0 +1,3 @@
+body {
+    background-color: pink;
+}

--- a/desktop-node-preact/ssc.config
+++ b/desktop-node-preact/ssc.config
@@ -1,0 +1,123 @@
+#
+# Build Settings
+#
+input: public
+# build: node ./build.js
+output: dist
+executable: ssc-hello
+# win_icon: src/icons/icons.ico
+# mac_icon: src/icons/icon.icns
+# linux_icon: src/icons/icon.png
+
+#
+# Package Metadata
+#
+# A unique ID that identifies the bundle (used by all app stores).
+bundle_identifier: com.beepboop
+# A string that gets used in the about dialog and package meta info.
+copyright: (c) Beep Boop Corp. 1985
+# A short description of the app
+description: A UI for the beep boop network
+# A boolean that determines if stdout and stderr should get forwarded
+# forward_console: true
+# A directory is where your application's code is located.
+# Localization
+lang: en-us
+name: ssc-test
+
+#
+# Code Signing
+#
+mac_sign: Voltra Co. BV (DYE7429KTV)
+win_publisher: CN=Operator Tool Co, O=Operator, L=New York, S=New York, C=US
+win_logo: icon.png
+
+
+#
+# Main Process
+#
+mac_cmd: node main.js
+win_cmd: node main.js
+linux_cmd: node main.js
+
+#
+# Advanced Compiler Settings, ie -O3, -g
+#
+flags: -O3
+debug_flags: -g
+
+# A String used in the about dialog and meta info.
+maintainer: Beep Boop Corp.
+
+#
+# window
+#
+# The initial title of the window (can have spaces and symbols etc).
+title: Beep Boop
+# The initial height of the first window.
+height: 750
+# The initial width of the first window.
+width: 1024
+# A string that indicates the version of the cli tool and resources.
+version: v0.0.1
+# A string that indicates the version for MacOS.
+version_short: 0.0.1
+# TODO: maybe the user doesn't need to know about this?
+# revision: 123
+# An array of environment variables, separated by commas
+env: SOCKET_ENV
+
+#
+# Windows
+# ---
+#
+
+#
+# MacOS and iOS
+# ---
+#
+
+# The team ID needed for MacOS and iOS distribution and development
+# apple_team_id:
+
+# Setting this to true will create a special build (that is absolutely
+# not secure) but it will allow you to attach the apple instruments apps
+# to the process while it is running on a device. You can learn more
+# here - https://help.apple.com/instruments/mac/current/#/dev7b09c84f5
+#
+# apple_instruments: true
+
+#
+# MacOS
+# ---
+#
+
+# Mac App Store icon
+# mac_appstore_icon: src/icons/icon.png
+
+# A category in the App Store
+# mac_category:
+
+# The command to execute to spawn the "back-end" process.
+# mac_cmd:
+
+# TODO description & value
+# mac_distribution_method:
+
+# TODO description & value
+# mac_entitlements:
+
+# The icon to use for identifying your app on MacOS.
+# mac_icon:
+
+# TODO description & value
+# mac_provisioning_profile:
+
+# TODO description & value
+# mac_sign:
+
+# TODO description & value
+# mac_codesign_identity:
+
+# TODO description & value
+# mac_sign_paths:

--- a/desktop-node-preact/test/test.js
+++ b/desktop-node-preact/test/test.js
@@ -1,0 +1,12 @@
+// @ts-check
+'use strict'
+const { test } = require('tapzero')
+const dom = require('@socketsupply/test-dom')
+
+test('find an element', async t => {
+    const el = await dom.waitFor({
+        selector: 'a'
+    })
+
+    t.ok(dom.isElementVisible(el), 'should find a visible link tag')
+})


### PR DESCRIPTION
Add an example demonstrating how to call a node API from the browser-side code. 

In `main`, we setup an RPC system similar to in `serverless-studio`.

```js
system.receive = async (command, value) => {
```